### PR TITLE
check custom is_ajax method

### DIFF
--- a/influxdb_metrics/middleware.py
+++ b/influxdb_metrics/middleware.py
@@ -1,6 +1,7 @@
 """Middlewares for the influxdb_metrics app."""
 import inspect
 import time
+
 try:
     from urllib import parse
 except ImportError:
@@ -12,11 +13,13 @@ from tld import get_tld
 from tld.exceptions import TldBadUrl, TldDomainNotFound, TldIOError
 
 from .loader import write_points
+from .utils import is_ajax
 
 try:
-      from django.utils.deprecation import MiddlewareMixin
+    from django.utils.deprecation import MiddlewareMixin
 except ImportError:
-      MiddlewareMixin = object
+    MiddlewareMixin = object
+
 
 class InfluxDBRequestMiddleware(MiddlewareMixin):
     """
@@ -25,6 +28,7 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
     Credits go to: https://github.com/andymckay/django-statsd/blob/master/django_statsd/middleware.py#L24  # NOQA
 
     """
+
     def process_view(self, request, view_func, view_args, view_kwargs):
         view = view_func
         if not inspect.isfunction(view_func):
@@ -46,7 +50,7 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
     def _record_time(self, request):
         if hasattr(request, '_start_time'):
             ms = int((time.time() - request._start_time) * 1000)
-            if request.is_ajax():
+            if is_ajax(request):
                 is_ajax = True
             else:
                 is_ajax = False

--- a/influxdb_metrics/middleware.py
+++ b/influxdb_metrics/middleware.py
@@ -13,7 +13,7 @@ from tld import get_tld
 from tld.exceptions import TldBadUrl, TldDomainNotFound, TldIOError
 
 from .loader import write_points
-from .utils import is_ajax
+from .utils import is_ajax as check_if_is_ajax
 
 try:
     from django.utils.deprecation import MiddlewareMixin
@@ -50,7 +50,7 @@ class InfluxDBRequestMiddleware(MiddlewareMixin):
     def _record_time(self, request):
         if hasattr(request, '_start_time'):
             ms = int((time.time() - request._start_time) * 1000)
-            if is_ajax(request):
+            if check_if_is_ajax(request):
                 is_ajax = True
             else:
                 is_ajax = False

--- a/influxdb_metrics/tests/utils_tests.py
+++ b/influxdb_metrics/tests/utils_tests.py
@@ -1,4 +1,5 @@
 """Tests for the utils module of the influxdb_metrics app."""
+from django.http import HttpRequest
 from django.test import TestCase
 
 from mock import patch
@@ -61,3 +62,14 @@ class WritePointsTestCase(TestCase):
             result = utils.write_points([])
             self.assertEqual(result, None, msg=(
                 'If setting is set, should return immediately'))
+
+
+class TestIsAjax(TestCase):
+    def test_ajax_request(self):
+        request = HttpRequest()
+        request.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+        self.assertTrue(is_ajax(request))
+
+    def test_non_ajax_request(self):
+        request = HttpRequest()
+        self.assertFalse(is_ajax(request))

--- a/influxdb_metrics/utils.py
+++ b/influxdb_metrics/utils.py
@@ -64,3 +64,7 @@ def process_points(client, data):  # pragma: no cover
             logger.error(err)
         else:
             raise err
+
+
+def is_ajax(request):
+    return request.META.get('HTTP_X_REQUESTED_WITH', '') == 'XMLHttpRequest'


### PR DESCRIPTION
request.is_ajax() is deprecated in Django 3.1

https://stackoverflow.com/questions/70419441/attributeerror-wsgirequest-object-has-no-attribute-is-ajax